### PR TITLE
Fixed certificate error and checking of existing copies

### DIFF
--- a/getuva_html.sh
+++ b/getuva_html.sh
@@ -17,7 +17,7 @@ do
 	for serial in $(seq 0 99);
 	do
 		problem_id=$((100 * $volume + $serial))
-        if [[ ! -f ./htmls/$volume/$problem_id.html ]]; then		
+        if [[ ! -f ./htmls/$volume/$problem_id.html ]] && [[ ! -f ./uva.onlinejudge.org/external/$volume/$problem_id.html ]]; then		
     		wget -p --no-parent --no-check-certificate http://uva.onlinejudge.org/external/$volume/$problem_id.html
     	fi
 	done

--- a/getuva_html.sh
+++ b/getuva_html.sh
@@ -18,7 +18,7 @@ do
 	do
 		problem_id=$((100 * $volume + $serial))
         if [[ ! -f ./htmls/$volume/$problem_id.html ]]; then		
-    		wget -p --no-parent http://uva.onlinejudge.org/external/$volume/$problem_id.html
+    		wget -p --no-parent --no-check-certificate http://uva.onlinejudge.org/external/$volume/$problem_id.html
     	fi
 	done
 

--- a/getuva_pdf.sh
+++ b/getuva_pdf.sh
@@ -19,7 +19,7 @@ do
 	do
 		problem_id=$((100 * $volume + $serial))
 			if [[ ! -f ./pdfs/$volume/$problem_id.pdf ]]; then    
-				wget http://uva.onlinejudge.org/external/$volume/$problem_id.pdf
+				wget --no-check-certificate http://uva.onlinejudge.org/external/$volume/$problem_id.pdf
 			fi
 	done
 

--- a/getuva_pdf.sh
+++ b/getuva_pdf.sh
@@ -18,7 +18,7 @@ do
 	for serial in $(seq 0 99);
 	do
 		problem_id=$((100 * $volume + $serial))
-			if [[ ! -f ./pdfs/$volume/$problem_id.pdf ]]; then    
+			if [[ ! -f ./pdfs/$volume/$problem_id.pdf ]] && [[ ! -f ./$problem_id.pdf ]]; then    
 				wget --no-check-certificate http://uva.onlinejudge.org/external/$volume/$problem_id.pdf
 			fi
 	done


### PR DESCRIPTION
Previously gave an error of unable to verify uva's certificate.
Copies that are downloaded to the working directory were not considered as existing copies. Stopping the script midway and running it again will result in downloading the same copies twice. I added a condition to check for these copies.